### PR TITLE
feat: update About Us link in Footer to navigate to /about

### DIFF
--- a/client/src/components/AboutPage.jsx
+++ b/client/src/components/AboutPage.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Container, Row, Col, Card, Button } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom'; // Import useNavigate
 
 const About = () => {
+  const navigate = useNavigate(); // Initialize the navigate function
+
   return (
     <Container className="custom-searchResult-margin mb-5">
       <h1 className="text-center mb-4">About BookHub</h1>
@@ -15,14 +18,14 @@ const About = () => {
               variant="top" 
               src="https://images.unsplash.com/photo-1600181982553-ce7d36051c01?q=80&w=1287&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" 
               alt="Book Community" 
-              className="img-fluid" // Added class to make the image fluid
+              className="img-fluid"
             />
             <Card.Body>
               <Card.Title>Join Our Community</Card.Title>
               <Card.Text>
                 At BookHub, we believe in the power of sharing knowledge and experiences. Join our vibrant community of readers and authors, and discover new books, authors, and genres.
               </Card.Text>
-              <Button variant="primary">Learn More</Button>
+              <Button variant="primary" onClick={() => navigate('/')}>Learn More</Button> {/* Navigate to home */}
             </Card.Body>
           </Card>
         </Col>
@@ -32,14 +35,14 @@ const About = () => {
               variant="top" 
               src="https://images.unsplash.com/photo-1535905496755-26ae35d0ae54?q=80&w=1287&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" 
               alt="Book Reviews" 
-              className="img-fluid" // Added class to make the image fluid
+              className="img-fluid"
             />
             <Card.Body>
               <Card.Title>Share Your Thoughts</Card.Title>
               <Card.Text>
                 We encourage our users to leave reviews and ratings for the books they read. Your opinions help fellow readers make informed decisions and foster a rich dialogue about literature.
               </Card.Text>
-              <Button variant="primary">Share a Review</Button>
+              <Button variant="primary" onClick={() => navigate('/')}>Share a Review</Button> {/* Navigate to home */}
             </Card.Body>
           </Card>
         </Col>
@@ -50,7 +53,7 @@ const About = () => {
           <p>
             Have books you no longer need? Sell them to fellow BookHub users and make some extra cash while helping others discover great reads.
           </p>
-          <Button variant="success">Start Selling</Button>
+          <Button variant="success" onClick={() => navigate('/books')}>Start Selling</Button> {/* Navigate to /books */}
         </Col>
       </Row>
     </Container>

--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Container, Row, Col, Nav } from 'react-bootstrap';
+import { Link } from 'react-router-dom'; // Import Link from react-router-dom
 import 'font-awesome/css/font-awesome.min.css'; // Ensure you have Font Awesome included
 import '../styles/Footer.css'; // Adjust path as necessary
 
@@ -23,12 +24,12 @@ const Footer = () => {
           </Col>
           <Col md={4}>
             <Nav className="footer-nav">
-              <Nav.Link href="#" >Help</Nav.Link>
-              <Nav.Link href="#" >Payment Methods</Nav.Link>
-              <Nav.Link href="#" >How to Use and Purchase</Nav.Link>
-              <Nav.Link href="#" >About Us</Nav.Link>
+              <Nav.Link href="#">Help</Nav.Link>
+              <Nav.Link href="#">Payment Methods</Nav.Link>
+              <Nav.Link href="#">How to Use and Purchase</Nav.Link>
+              <Nav.Link as={Link} to="/about">About Us</Nav.Link> {/* Updated Link */}
             </Nav>
-              </Col>
+          </Col>
         </Row>
       </Container>
     </footer>


### PR DESCRIPTION
- Replaced traditional <a> tag with React Router's Link component.
- Ensured "About Us" in the footer now correctly routes to the /about page.
- Imported Link from react-router-dom